### PR TITLE
LPS-53139 Fix test. Was not really checking the LayoutSetPrototype merging errors

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/lar/LayoutSetPrototypePropagationTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/LayoutSetPrototypePropagationTest.java
@@ -182,8 +182,13 @@ public class LayoutSetPrototypePropagationTest
 
 		LayoutSet layoutSet = group.getPublicLayoutSet();
 
-		List<Layout> initialMergeFailFriendlyURLLayouts =
-			SitesUtil.getMergeFailFriendlyURLLayouts(layoutSet);
+		long layoutSetPrototypeId = layoutSet.getLayoutSetPrototypeId();
+		
+		LayoutSetPrototype layoutSetPrototype = LayoutSetPrototypeLocalServiceUtil
+						.getLayoutSetPrototype(layoutSetPrototypeId);
+
+		long initialMergeFailFriendlyURLLayouts =
+			SitesUtil.getMergeFailCount(layoutSetPrototype);
 
 		setLinkEnabled(true);
 
@@ -193,15 +198,15 @@ public class LayoutSetPrototypePropagationTest
 
 		propagateChanges(group);
 
-		layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
-			layoutSet.getLayoutSetId());
+		layoutSetPrototype = LayoutSetPrototypeLocalServiceUtil.getLayoutSetPrototype(
+			layoutSetPrototypeId);
 
-		List<Layout> mergeFailFriendlyURLLayouts =
-			SitesUtil.getMergeFailFriendlyURLLayouts(layoutSet);
+		long mergeFailFriendlyURLLayouts =
+			SitesUtil.getMergeFailCount(layoutPrototype);
 
 		Assert.assertEquals(
-			initialMergeFailFriendlyURLLayouts.size() + 1,
-			mergeFailFriendlyURLLayouts.size());
+			initialMergeFailFriendlyURLLayouts,
+			mergeFailFriendlyURLLayouts);
 	}
 
 	@Test

--- a/portal-impl/test/integration/com/liferay/portal/lar/LayoutSetPrototypePropagationTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/LayoutSetPrototypePropagationTest.java
@@ -61,7 +61,6 @@ import com.liferay.portlet.util.test.PortletKeys;
 
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.portlet.PortletPreferences;
@@ -183,12 +182,13 @@ public class LayoutSetPrototypePropagationTest
 		LayoutSet layoutSet = group.getPublicLayoutSet();
 
 		long layoutSetPrototypeId = layoutSet.getLayoutSetPrototypeId();
-		
-		LayoutSetPrototype layoutSetPrototype = LayoutSetPrototypeLocalServiceUtil
-						.getLayoutSetPrototype(layoutSetPrototypeId);
 
-		long initialMergeFailFriendlyURLLayouts =
-			SitesUtil.getMergeFailCount(layoutSetPrototype);
+		LayoutSetPrototype layoutSetPrototype =
+				LayoutSetPrototypeLocalServiceUtil.getLayoutSetPrototype(
+					layoutSetPrototypeId);
+
+		long initialMergeFailFriendlyURLLayouts = SitesUtil.getMergeFailCount(
+			layoutSetPrototype);
 
 		setLinkEnabled(true);
 
@@ -198,15 +198,15 @@ public class LayoutSetPrototypePropagationTest
 
 		propagateChanges(group);
 
-		layoutSetPrototype = LayoutSetPrototypeLocalServiceUtil.getLayoutSetPrototype(
-			layoutSetPrototypeId);
+		layoutSetPrototype =
+						LayoutSetPrototypeLocalServiceUtil.
+						getLayoutSetPrototype(layoutSetPrototypeId);
 
-		long mergeFailFriendlyURLLayouts =
-			SitesUtil.getMergeFailCount(layoutPrototype);
+		long mergeFailFriendlyURLLayouts = SitesUtil.getMergeFailCount(
+			layoutSetPrototype);
 
 		Assert.assertEquals(
-			initialMergeFailFriendlyURLLayouts,
-			mergeFailFriendlyURLLayouts);
+			initialMergeFailFriendlyURLLayouts, mergeFailFriendlyURLLayouts);
 	}
 
 	@Test

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -120,7 +120,7 @@
         portal-impl/src/com/liferay/portal/tools/WebXML23Converter.java@81,\
         portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java,\
         portal-impl/src/com/liferay/portal/util/WebKeys.java,\
-        portal-impl/test/integration/com/liferay/portal/lar/LayoutSetPrototypePropagationTest.java@256,\
+        portal-impl/test/integration/com/liferay/portal/lar/LayoutSetPrototypePropagationTest.java@261,\
         portal-impl/test/integration/com/liferay/portal/util/PortalImplCanonicalURLTest.java,\
         portal-impl/test/integration/com/liferay/portal/util/PortalImplLocalizedFriendlyURLTest.java,\
         portal-impl/test/integration/com/liferay/portal/service/PortletPreferencesLocalServiceTest.java,\


### PR DESCRIPTION
Hola @epgarcia.

When backporting these commits I saw the test was bad and it wasn't really checking the merge errors. In this case, the method should be SitesUtil.getMergeFailCount, as it's there the errors added whenever a merge fail occurs.

Thanks!