### PR TITLE
LPS-55762 Standardize how portlet instance configuration is used in the views

### DIFF
--- a/modules/apps/asset/asset-categories-navigation-web/src/META-INF/resources/configuration.jsp
+++ b/modules/apps/asset/asset-categories-navigation-web/src/META-INF/resources/configuration.jsp
@@ -26,13 +26,13 @@
 
 	<aui:fieldset>
 		<aui:select label="vocabularies" name="preferences--allAssetVocabularies--">
-			<aui:option label="all" selected="<%= assetCategoriesNavigationDisplayContext.isAllAssetVocabularies() %>" value="<%= true %>" />
-			<aui:option label="filter[action]" selected="<%= !assetCategoriesNavigationDisplayContext.isAllAssetVocabularies() %>" value="<%= false %>" />
+			<aui:option label="all" selected="<%= assetCategoriesNavigationPortletInstanceConfiguration.allAssetVocabularies() %>" value="<%= true %>" />
+			<aui:option label="filter[action]" selected="<%= !assetCategoriesNavigationPortletInstanceConfiguration.allAssetVocabularies() %>" value="<%= false %>" />
 		</aui:select>
 
 		<aui:input name="preferences--assetVocabularyIds--" type="hidden" />
 
-		<div class="<%= assetCategoriesNavigationDisplayContext.isAllAssetVocabularies() ? "hide" : "" %>" id="<portlet:namespace />assetVocabulariesBoxes">
+		<div class="<%= assetCategoriesNavigationPortletInstanceConfiguration.allAssetVocabularies() ? "hide" : "" %>" id="<portlet:namespace />assetVocabulariesBoxes">
 			<liferay-ui:input-move-boxes
 				leftBoxName="currentAssetVocabularyIds"
 				leftList="<%= assetCategoriesNavigationDisplayContext.getCurrentVocabularyNames() %>"
@@ -47,7 +47,7 @@
 		<div class="display-template">
 			<liferay-ui:ddm-template-selector
 				className="<%= AssetCategory.class.getName() %>"
-				displayStyle="<%= assetCategoriesNavigationDisplayContext.getDisplayStyle() %>"
+				displayStyle="<%= assetCategoriesNavigationPortletInstanceConfiguration.displayStyle() %>"
 				displayStyleGroupId="<%= assetCategoriesNavigationDisplayContext.getDisplayStyleGroupId() %>"
 				refreshURL="<%= configurationRenderURL %>"
 				showEmptyOption="<%= true %>"

--- a/modules/apps/asset/asset-categories-navigation-web/src/META-INF/resources/init.jsp
+++ b/modules/apps/asset/asset-categories-navigation-web/src/META-INF/resources/init.jsp
@@ -23,7 +23,8 @@
 <%@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 <%@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.asset.categories.navigation.web.display.context.AssetCategoriesNavigationDisplayContext" %><%@
+<%@ page import="com.liferay.asset.categories.navigation.web.configuration.AssetCategoriesNavigationPortletInstanceConfiguration" %><%@
+page import="com.liferay.asset.categories.navigation.web.display.context.AssetCategoriesNavigationDisplayContext" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portlet.asset.model.AssetCategory" %>
 
@@ -32,6 +33,8 @@ page import="com.liferay.portlet.asset.model.AssetCategory" %>
 
 <%
 AssetCategoriesNavigationDisplayContext assetCategoriesNavigationDisplayContext = new AssetCategoriesNavigationDisplayContext(request);
+
+AssetCategoriesNavigationPortletInstanceConfiguration assetCategoriesNavigationPortletInstanceConfiguration = assetCategoriesNavigationDisplayContext.getAssetCategoriesNavigationPortletInstanceConfiguration();
 %>
 
 <%@ include file="/init-ext.jsp" %>

--- a/modules/apps/asset/asset-categories-navigation-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-categories-navigation-web/src/META-INF/resources/view.jsp
@@ -16,9 +16,9 @@
 
 <%@ include file="/init.jsp" %>
 
-<liferay-ui:ddm-template-renderer className="<%= AssetCategory.class.getName() %>" displayStyle="<%= assetCategoriesNavigationDisplayContext.getDisplayStyle() %>" displayStyleGroupId="<%= assetCategoriesNavigationDisplayContext.getDisplayStyleGroupId() %>" entries="<%= assetCategoriesNavigationDisplayContext.getDDMTemplateAssetVocabularies() %>">
+<liferay-ui:ddm-template-renderer className="<%= AssetCategory.class.getName() %>" displayStyle="<%= assetCategoriesNavigationPortletInstanceConfiguration.displayStyle() %>" displayStyleGroupId="<%= assetCategoriesNavigationDisplayContext.getDisplayStyleGroupId() %>" entries="<%= assetCategoriesNavigationDisplayContext.getDDMTemplateAssetVocabularies() %>">
 	<c:choose>
-		<c:when test="<%= assetCategoriesNavigationDisplayContext.isAllAssetVocabularies() %>">
+		<c:when test="<%= assetCategoriesNavigationPortletInstanceConfiguration.allAssetVocabularies() %>">
 			<liferay-ui:asset-categories-navigation
 				hidePortletWhenEmpty="<%= true %>"
 			/>

--- a/modules/apps/asset/asset-categories-navigation-web/src/com/liferay/asset/categories/navigation/web/display/context/AssetCategoriesNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/com/liferay/asset/categories/navigation/web/display/context/AssetCategoriesNavigationDisplayContext.java
@@ -58,6 +58,12 @@ public class AssetCategoriesNavigationDisplayContext {
 				AssetCategoriesNavigationPortletInstanceConfiguration.class);
 	}
 
+	public AssetCategoriesNavigationPortletInstanceConfiguration
+		getAssetCategoriesNavigationPortletInstanceConfiguration() {
+
+		return _assetCategoriesNavigationPortletInstanceConfiguration;
+	}
+
 	public List<AssetVocabulary> getAssetVocabularies() throws PortalException {
 		if (_assetVocabularies != null) {
 			return _assetVocabularies;
@@ -194,18 +200,6 @@ public class AssetCategoriesNavigationDisplayContext {
 		return _ddmTemplateAssetVocabularies;
 	}
 
-	public String getDisplayStyle() {
-		if (_displayStyle != null) {
-			return _displayStyle;
-		}
-
-		_displayStyle =
-			_assetCategoriesNavigationPortletInstanceConfiguration.
-				displayStyle();
-
-		return _displayStyle;
-	}
-
 	public long getDisplayStyleGroupId() {
 		if (_displayStyleGroupId != 0) {
 			return _displayStyleGroupId;
@@ -225,18 +219,6 @@ public class AssetCategoriesNavigationDisplayContext {
 		return _displayStyleGroupId;
 	}
 
-	public boolean isAllAssetVocabularies() {
-		if (_allAssetVocabularies != null) {
-			return _allAssetVocabularies;
-		}
-
-		_allAssetVocabularies =
-			_assetCategoriesNavigationPortletInstanceConfiguration.
-				allAssetVocabularies();
-
-		return _allAssetVocabularies;
-	}
-
 	protected String getTitle(AssetVocabulary assetVocabulary) {
 		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -250,14 +232,12 @@ public class AssetCategoriesNavigationDisplayContext {
 		return title;
 	}
 
-	private Boolean _allAssetVocabularies;
 	private final AssetCategoriesNavigationPortletInstanceConfiguration
 		_assetCategoriesNavigationPortletInstanceConfiguration;
 	private List<AssetVocabulary> _assetVocabularies;
 	private long[] _assetVocabularyIds;
 	private long[] _availableAssetVocabularyIds;
 	private List<AssetVocabulary> _ddmTemplateAssetVocabularies;
-	private String _displayStyle;
 	private long _displayStyleGroupId;
 	private final HttpServletRequest _request;
 

--- a/modules/apps/asset/asset-categories-navigation-web/src/com/liferay/asset/categories/navigation/web/settings/internal/AssetCategoriesNavigationPortletInstanceConfigurationBeanDeclaration.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/com/liferay/asset/categories/navigation/web/settings/internal/AssetCategoriesNavigationPortletInstanceConfigurationBeanDeclaration.java
@@ -28,7 +28,7 @@ public class
 		implements ConfigurationBeanDeclaration {
 
 	@Override
-	public Class getConfigurationBeanClass() {
+	public Class<?> getConfigurationBeanClass() {
 		return AssetCategoriesNavigationPortletInstanceConfiguration.class;
 	}
 

--- a/modules/apps/iframe/iframe-web/src/META-INF/resources/configuration.jsp
+++ b/modules/apps/iframe/iframe-web/src/META-INF/resources/configuration.jsp
@@ -18,15 +18,15 @@
 
 <%
 String htmlAttributes =
-	"alt=" + iFrameDisplayContext.getAlt() + "\n" +
-	"border=" + iFrameDisplayContext.getBorder() + "\n" +
-	"bordercolor=" + iFrameDisplayContext.getBordercolor() + "\n" +
-	"frameborder=" + iFrameDisplayContext.getFrameborder() + "\n" +
-	"hspace=" + iFrameDisplayContext.getHspace() + "\n" +
-	"longdesc=" + iFrameDisplayContext.getLongdesc() + "\n" +
-	"scrolling=" + iFrameDisplayContext.getScrolling() + "\n" +
-	"title=" + iFrameDisplayContext.getTitle() + "\n" +
-	"vspace=" + iFrameDisplayContext.getVspace() + "\n";
+	"alt=" + iFramePortletInstanceConfiguration.alt() + "\n" +
+	"border=" + iFramePortletInstanceConfiguration.border() + "\n" +
+	"bordercolor=" + iFramePortletInstanceConfiguration.bordercolor() + "\n" +
+	"frameborder=" + iFramePortletInstanceConfiguration.frameborder() + "\n" +
+	"hspace=" + iFramePortletInstanceConfiguration.hspace() + "\n" +
+	"longdesc=" + iFramePortletInstanceConfiguration.longdesc() + "\n" +
+	"scrolling=" + iFramePortletInstanceConfiguration.scrolling() + "\n" +
+	"title=" + iFramePortletInstanceConfiguration.title() + "\n" +
+	"vspace=" + iFramePortletInstanceConfiguration.vspace() + "\n";
 %>
 
 <liferay-portlet:actionURL portletConfiguration="<%= true %>" var="configurationActionURL" />
@@ -40,15 +40,15 @@ String htmlAttributes =
 	<liferay-ui:panel-container extended="<%= true %>" id="iframeSettingsPanelContainer" persistState="<%= true %>">
 		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="iframeGeneralPanel" persistState="<%= true %>" title="general">
 			<aui:fieldset>
-				<aui:input autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) || windowState.equals(LiferayWindowState.POP_UP) %>" cssClass="lfr-input-text-container" label="source-url" name="preferences--src--" prefix="<%= iFrameDisplayContext.isRelative() ? StringPool.TRIPLE_PERIOD : StringPool.BLANK %>" type="text" value="<%= iFrameDisplayContext.getSrc() %>" />
+				<aui:input autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) || windowState.equals(LiferayWindowState.POP_UP) %>" cssClass="lfr-input-text-container" label="source-url" name="preferences--src--" prefix="<%= iFramePortletInstanceConfiguration.relative() ? StringPool.TRIPLE_PERIOD : StringPool.BLANK %>" type="text" value="<%= iFramePortletInstanceConfiguration.src() %>" />
 
-				<aui:input label="relative-to-context-path" name="preferences--relative--" type="checkbox" value="<%= iFrameDisplayContext.isRelative() %>" />
+				<aui:input label="relative-to-context-path" name="preferences--relative--" type="checkbox" value="<%= iFramePortletInstanceConfiguration.relative() %>" />
 			</aui:fieldset>
 		</liferay-ui:panel>
 
 		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="iframeAuthenticationPanel" persistState="<%= true %>" title="authenticate">
 			<aui:fieldset>
-				<aui:input label="authenticate" name="preferences--auth--" type="checkbox" value="<%= iFrameDisplayContext.isAuth() %>" />
+				<aui:input label="authenticate" name="preferences--auth--" type="checkbox" value="<%= iFramePortletInstanceConfiguration.auth() %>" />
 
 				<div id="<portlet:namespace />authenticationOptions">
 					<div class="alert alert-info" id="<portlet:namespace />currentLoginMsg">
@@ -77,10 +77,10 @@ String htmlAttributes =
 							<table class="lfr-table">
 							<tr>
 								<td>
-									<aui:input cssClass="lfr-input-text-container" label="field-name" name="preferences--userNameField--" type="text" value="<%= iFrameDisplayContext.getUserNameField() %>" />
+									<aui:input cssClass="lfr-input-text-container" label="field-name" name="preferences--userNameField--" type="text" value="<%= iFramePortletInstanceConfiguration.userNameField() %>" />
 								</td>
 								<td>
-									<aui:input cssClass="lfr-input-text-container" label="value" name="preferences--formUserName--" type="text" value="<%= iFrameDisplayContext.getFormUserName() %>" />
+									<aui:input cssClass="lfr-input-text-container" label="value" name="preferences--formUserName--" type="text" value="<%= iFramePortletInstanceConfiguration.formUserName() %>" />
 								</td>
 							</tr>
 							</table>
@@ -90,10 +90,10 @@ String htmlAttributes =
 							<table class="lfr-table">
 							<tr>
 								<td>
-									<aui:input cssClass="lfr-input-text-container" label="field-name" name="preferences--passwordField--" type="text" value="<%= iFrameDisplayContext.getPasswordField() %>" />
+									<aui:input cssClass="lfr-input-text-container" label="field-name" name="preferences--passwordField--" type="text" value="<%= iFramePortletInstanceConfiguration.passwordField() %>" />
 								</td>
 								<td>
-									<aui:input cssClass="lfr-input-text-container" label="value" name="preferences--formPassword--" type="text" value="<%= iFrameDisplayContext.getFormPassword() %>" />
+									<aui:input cssClass="lfr-input-text-container" label="value" name="preferences--formPassword--" type="text" value="<%= iFramePortletInstanceConfiguration.formPassword() %>" />
 								</td>
 							</tr>
 							</table>
@@ -103,9 +103,9 @@ String htmlAttributes =
 					</div>
 
 					<div id="<portlet:namespace />basicAuthOptions">
-						<aui:input cssClass="lfr-input-text-container" label="user-name" name="preferences--basicUserName--" type="text" value="<%= iFrameDisplayContext.getBasicUserName() %>" />
+						<aui:input cssClass="lfr-input-text-container" label="user-name" name="preferences--basicUserName--" type="text" value="<%= iFramePortletInstanceConfiguration.basicUserName() %>" />
 
-						<aui:input cssClass="lfr-input-text-container" label="password" name="preferences--basicPassword--" type="text" value="<%= iFrameDisplayContext.getBasicPassword() %>" />
+						<aui:input cssClass="lfr-input-text-container" label="password" name="preferences--basicPassword--" type="text" value="<%= iFramePortletInstanceConfiguration.basicPassword() %>" />
 					</div>
 				</div>
 			</aui:fieldset>
@@ -113,20 +113,20 @@ String htmlAttributes =
 
 		<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="iframeDisplaySettingsPanel" persistState="<%= true %>" title="display-settings">
 			<aui:fieldset>
-				<aui:input label="resize-automatically" name="preferences--resizeAutomatically--" type="checkbox" value="<%= iFrameDisplayContext.isResizeAutomatically() %>" />
+				<aui:input label="resize-automatically" name="preferences--resizeAutomatically--" type="checkbox" value="<%= iFramePortletInstanceConfiguration.resizeAutomatically() %>" />
 
 				<div id="<portlet:namespace />displaySettings">
-					<aui:input name="preferences--heightMaximized--" type="text" value="<%= iFrameDisplayContext.getHeightMaximized() %>">
+					<aui:input name="preferences--heightMaximized--" type="text" value="<%= iFramePortletInstanceConfiguration.heightMaximized() %>">
 						<aui:validator name="digits" />
 						<aui:validator name="required" />
 					</aui:input>
 
-					<aui:input name="preferences--heightNormal--" type="text" value="<%= iFrameDisplayContext.getHeightNormal() %>">
+					<aui:input name="preferences--heightNormal--" type="text" value="<%= iFramePortletInstanceConfiguration.heightNormal() %>">
 						<aui:validator name="digits" />
 						<aui:validator name="required" />
 					</aui:input>
 
-					<aui:input name="preferences--width--" type="text" value="<%= iFrameDisplayContext.getWidth() %>" />
+					<aui:input name="preferences--width--" type="text" value="<%= iFramePortletInstanceConfiguration.width() %>" />
 				</div>
 
 				<aui:input cssClass="lfr-textarea-container" name="preferences--htmlAttributes--" onKeyDown="Liferay.Util.checkTab(this); Liferay.Util.disableEsc();" type="textarea" value="<%= htmlAttributes %>" wrap="soft" />

--- a/modules/apps/iframe/iframe-web/src/META-INF/resources/init.jsp
+++ b/modules/apps/iframe/iframe-web/src/META-INF/resources/init.jsp
@@ -24,6 +24,7 @@
 <%@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.iframe.web.configuration.IFrameConfiguration" %><%@
+page import="com.liferay.iframe.web.configuration.IFramePortletInstanceConfiguration" %><%@
 page import="com.liferay.iframe.web.display.context.IFrameDisplayContext" %><%@
 page import="com.liferay.iframe.web.util.IFrameUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
@@ -45,6 +46,8 @@ WindowState windowState = liferayPortletRequest.getWindowState();
 IFrameConfiguration iFrameConfiguration = (IFrameConfiguration)renderRequest.getAttribute(IFrameConfiguration.class.getName());
 
 IFrameDisplayContext iFrameDisplayContext = new IFrameDisplayContext(iFrameConfiguration, renderRequest);
+
+IFramePortletInstanceConfiguration iFramePortletInstanceConfiguration = iFrameDisplayContext.getIFramePortletInstanceConfiguration();
 %>
 
 <%@ include file="/init-ext.jsp" %>

--- a/modules/apps/iframe/iframe-web/src/META-INF/resources/proxy.jsp
+++ b/modules/apps/iframe/iframe-web/src/META-INF/resources/proxy.jsp
@@ -26,7 +26,7 @@
 
 <body onLoad="setTimeout('document.fm.submit()', 100);">
 
-<form action="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getSrc()) %>" method="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getFormMethod()) %>" name="fm">
+<form action="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.src()) %>" method="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getFormMethod()) %>" name="fm">
 
 <%
 for (KeyValuePair hiddenVariableKVP : iFrameDisplayContext.getHiddenVariableKVPs()) {
@@ -38,9 +38,9 @@ for (KeyValuePair hiddenVariableKVP : iFrameDisplayContext.getHiddenVariableKVPs
 }
 %>
 
-<input name="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getUserNameField()) %>" type="hidden" value="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getUserName()) %>" />
+<input name="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.userNameField()) %>" type="hidden" value="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getUserName()) %>" />
 
-<input name="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getPasswordField()) %>" type="hidden" value="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getPassword()) %>" />
+<input name="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.passwordField()) %>" type="hidden" value="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getPassword()) %>" />
 
 </form>
 

--- a/modules/apps/iframe/iframe-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/iframe/iframe-web/src/META-INF/resources/view.jsp
@@ -17,14 +17,14 @@
 <%@ include file="/init.jsp" %>
 
 <c:choose>
-	<c:when test="<%= iFrameDisplayContext.isAuth() && Validator.isNull(iFrameDisplayContext.getUserName()) && !themeDisplay.isSignedIn() %>">
+	<c:when test="<%= iFramePortletInstanceConfiguration.auth() && Validator.isNull(iFrameDisplayContext.getUserName()) && !themeDisplay.isSignedIn() %>">
 		<div class="alert alert-info">
 			<a href="<%= themeDisplay.getURLSignIn() %>" target="_top"><liferay-ui:message key="please-sign-in-to-access-this-application" /></a>
 		</div>
 	</c:when>
 	<c:otherwise>
 		<div class="iframe-container">
-			<iframe alt="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getAlt()) %>" border="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getBorder()) %>" bordercolor="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getBordercolor()) %>" frameborder="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getFrameborder()) %>" height="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getHeight()) %>" hspace="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getHspace()) %>" id="<portlet:namespace />iframe" longdesc="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getLongdesc()) %>" name="<portlet:namespace />iframe" onload="<portlet:namespace />monitorIframe();" scrolling="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getScrolling()) %>" src="<%= HtmlUtil.escapeHREF(iFrameDisplayContext.getIframeSrc()) %>" title="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getTitle()) %>" vspace="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getVspace()) %>" width="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getWidth()) %>">
+			<iframe alt="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.alt()) %>" border="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.border()) %>" bordercolor="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.bordercolor()) %>" frameborder="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.frameborder()) %>" height="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getHeight()) %>" hspace="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.hspace()) %>" id="<portlet:namespace />iframe" longdesc="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.longdesc()) %>" name="<portlet:namespace />iframe" onload="<portlet:namespace />monitorIframe();" scrolling="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.scrolling()) %>" src="<%= HtmlUtil.escapeHREF(iFrameDisplayContext.getIframeSrc()) %>" title="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.title()) %>" vspace="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.vspace()) %>" width="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.width()) %>">
 				<liferay-ui:message
 					arguments="<%= HtmlUtil.escape(iFrameDisplayContext.getIframeSrc()) %>"
 					key="your-browser-does-not-support-inline-frames-or-is-currently-configured-not-to-display-inline-frames.-content-can-be-viewed-at-actual-source-page-x"
@@ -155,7 +155,7 @@
 		iframe.plug(
 			A.Plugin.AutosizeIframe,
 			{
-				monitorHeight: <%= iFrameDisplayContext.isResizeAutomatically() %>
+				monitorHeight: <%= iFramePortletInstanceConfiguration.resizeAutomatically() %>
 			}
 		);
 
@@ -165,10 +165,10 @@
 				var height = A.Plugin.AutosizeIframe.getContentHeight(iframe);
 
 				if (height == null) {
-					height = '<%= HtmlUtil.escapeJS(iFrameDisplayContext.getHeightNormal()) %>';
+					height = '<%= HtmlUtil.escapeJS(iFramePortletInstanceConfiguration.heightNormal()) %>';
 
 					if (themeDisplay.isStateMaximized()) {
-						height = '<%= HtmlUtil.escapeJS(iFrameDisplayContext.getHeightMaximized()) %>';
+						height = '<%= HtmlUtil.escapeJS(iFramePortletInstanceConfiguration.heightMaximized()) %>';
 					}
 
 					iframe.setStyle('height', height);

--- a/modules/apps/iframe/iframe-web/src/com/liferay/iframe/web/display/context/IFrameDisplayContext.java
+++ b/modules/apps/iframe/iframe-web/src/com/liferay/iframe/web/display/context/IFrameDisplayContext.java
@@ -59,16 +59,6 @@ public class IFrameDisplayContext {
 				IFramePortletInstanceConfiguration.class);
 	}
 
-	public String getAlt() {
-		if (_alt != null) {
-			return _alt;
-		}
-
-		_alt = _iFramePortletInstanceConfiguration.alt();
-
-		return _alt;
-	}
-
 	public String getAuthType() {
 		if (_authType != null) {
 			return _authType;
@@ -81,46 +71,6 @@ public class IFrameDisplayContext {
 		}
 
 		return _authType;
-	}
-
-	public String getBasicPassword() {
-		if (_basicPassword != null) {
-			return _basicPassword;
-		}
-
-		_basicPassword = _iFramePortletInstanceConfiguration.basicPassword();
-
-		return _basicPassword;
-	}
-
-	public String getBasicUserName() {
-		if (_basicUserName != null) {
-			return _basicUserName;
-		}
-
-		_basicUserName = _iFramePortletInstanceConfiguration.basicUserName();
-
-		return _basicUserName;
-	}
-
-	public String getBorder() {
-		if (_border != null) {
-			return _border;
-		}
-
-		_border = _iFramePortletInstanceConfiguration.border();
-
-		return _border;
-	}
-
-	public String getBordercolor() {
-		if (_bordercolor != null) {
-			return _bordercolor;
-		}
-
-		_bordercolor = _iFramePortletInstanceConfiguration.bordercolor();
-
-		return _bordercolor;
 	}
 
 	public String getFormMethod() {
@@ -137,36 +87,6 @@ public class IFrameDisplayContext {
 		return _formMethod;
 	}
 
-	public String getFormPassword() {
-		if (_formPassword != null) {
-			return _formPassword;
-		}
-
-		_formPassword = _iFramePortletInstanceConfiguration.formPassword();
-
-		return _formPassword;
-	}
-
-	public String getFormUserName() {
-		if (_formUserName != null) {
-			return _formUserName;
-		}
-
-		_formUserName = _iFramePortletInstanceConfiguration.formUserName();
-
-		return _formUserName;
-	}
-
-	public String getFrameborder() {
-		if (_frameborder != null) {
-			return _frameborder;
-		}
-
-		_frameborder = _iFramePortletInstanceConfiguration.frameborder();
-
-		return _frameborder;
-	}
-
 	public String getHeight() {
 		if (_height != null) {
 			return _height;
@@ -175,34 +95,13 @@ public class IFrameDisplayContext {
 		String windowState = String.valueOf(_request.getWindowState());
 
 		if (windowState.equals(WindowState.MAXIMIZED)) {
-			_height = getHeightMaximized();
+			_height = _iFramePortletInstanceConfiguration.heightMaximized();
 		}
 		else {
-			_height = getHeightNormal();
+			_height = _iFramePortletInstanceConfiguration.heightNormal();
 		}
 
 		return _height;
-	}
-
-	public String getHeightMaximized() {
-		if (_heightMaximized != null) {
-			return _heightMaximized;
-		}
-
-		_heightMaximized =
-			_iFramePortletInstanceConfiguration.heightMaximized();
-
-		return _heightMaximized;
-	}
-
-	public String getHeightNormal() {
-		if (_heightNormal != null) {
-			return _heightNormal;
-		}
-
-		_heightNormal = _iFramePortletInstanceConfiguration.heightNormal();
-
-		return _heightNormal;
 	}
 
 	public List<KeyValuePair> getHiddenVariableKVPs() {
@@ -246,16 +145,6 @@ public class IFrameDisplayContext {
 		return _hiddenVariables;
 	}
 
-	public String getHspace() {
-		if (_hspace != null) {
-			return _hspace;
-		}
-
-		_hspace = _iFramePortletInstanceConfiguration.hspace();
-
-		return _hspace;
-	}
-
 	public String getIframeBaseSrc() {
 		if (_iFrameBaseSrc != null) {
 			return _iFrameBaseSrc;
@@ -276,6 +165,12 @@ public class IFrameDisplayContext {
 		return _iFrameBaseSrc;
 	}
 
+	public IFramePortletInstanceConfiguration
+		getIFramePortletInstanceConfiguration() {
+
+		return _iFramePortletInstanceConfiguration;
+	}
+
 	public String getIframeSrc() {
 		if (_iFrameSrc != null) {
 			return _iFrameSrc;
@@ -283,7 +178,7 @@ public class IFrameDisplayContext {
 
 		_iFrameSrc = StringPool.BLANK;
 
-		if (isRelative()) {
+		if (_iFramePortletInstanceConfiguration.relative()) {
 			_iFrameSrc = _themeDisplay.getPathContext();
 		}
 
@@ -322,16 +217,6 @@ public class IFrameDisplayContext {
 		return iFrameVariables;
 	}
 
-	public String getLongdesc() {
-		if (_longdesc != null) {
-			return _longdesc;
-		}
-
-		_longdesc = _iFramePortletInstanceConfiguration.longdesc();
-
-		return _longdesc;
-	}
-
 	public String getPassword() throws PortalException {
 		if (_password != null) {
 			return _password;
@@ -340,73 +225,36 @@ public class IFrameDisplayContext {
 		String authType = getAuthType();
 
 		if (authType.equals("basic")) {
-			_password = getBasicPassword();
+			_password = _iFramePortletInstanceConfiguration.basicPassword();
 		}
 		else {
-			_password = getFormPassword();
+			_password = _iFramePortletInstanceConfiguration.formPassword();
 		}
 
 		if (Validator.isNull(_password)) {
 			return StringPool.BLANK;
 		}
 
-		if (Validator.isNull(getPasswordField())) {
+		String passwordField =
+			_iFramePortletInstanceConfiguration.passwordField();
+
+		if (Validator.isNull(passwordField)) {
 			int pos = _password.indexOf(StringPool.EQUAL);
 
 			if (pos != -1) {
 				String fieldValuePair = _password;
 
-				_passwordField = fieldValuePair.substring(0, pos);
+				passwordField = fieldValuePair.substring(0, pos);
 
 				_password = fieldValuePair.substring(pos + 1);
 			}
 		}
 
-		if (Validator.isNotNull(getPasswordField())) {
+		if (Validator.isNotNull(passwordField)) {
 			_password = IFrameUtil.getPassword(_request, _password);
 		}
 
 		return _password;
-	}
-
-	public String getPasswordField() {
-		if (_passwordField != null) {
-			return _passwordField;
-		}
-
-		_passwordField = _iFramePortletInstanceConfiguration.passwordField();
-
-		return _passwordField;
-	}
-
-	public String getScrolling() {
-		if (_scrolling != null) {
-			return _scrolling;
-		}
-
-		_scrolling = _iFramePortletInstanceConfiguration.scrolling();
-
-		return _scrolling;
-	}
-
-	public String getSrc() {
-		if (_src != null) {
-			return _src;
-		}
-
-		_src = _iFramePortletInstanceConfiguration.src();
-
-		return _src;
-	}
-
-	public String getTitle() {
-		if (_title != null) {
-			return _title;
-		}
-
-		_title = _iFramePortletInstanceConfiguration.title();
-
-		return _title;
 	}
 
 	public String getUserName() throws PortalException {
@@ -417,132 +265,52 @@ public class IFrameDisplayContext {
 		String authType = getAuthType();
 
 		if (authType.equals("basic")) {
-			_userName = getBasicUserName();
+			_userName = _iFramePortletInstanceConfiguration.basicUserName();
 		}
 		else {
-			_userName = getFormUserName();
+			_userName = _iFramePortletInstanceConfiguration.formUserName();
 		}
 
 		if (Validator.isNull(_userName)) {
 			return StringPool.BLANK;
 		}
 
-		if (Validator.isNull(getUserNameField())) {
+		String userNameField =
+			_iFramePortletInstanceConfiguration.userNameField();
+
+		if (Validator.isNull(userNameField)) {
 			int pos = _userName.indexOf(StringPool.EQUAL);
 
 			if (pos != -1) {
 				String fieldValuePair = _userName;
 
-				_userNameField = fieldValuePair.substring(0, pos);
+				userNameField = fieldValuePair.substring(0, pos);
 
 				_userName = fieldValuePair.substring(pos + 1);
 			}
 		}
 
-		if (Validator.isNotNull(getUserNameField())) {
+		if (Validator.isNotNull(userNameField)) {
 			_userName = IFrameUtil.getUserName(_request, _userName);
 		}
 
 		return _userName;
 	}
 
-	public String getUserNameField() {
-		if (_userNameField != null) {
-			return _userNameField;
-		}
-
-		_userNameField = _iFramePortletInstanceConfiguration.userNameField();
-
-		return _userNameField;
-	}
-
-	public String getVspace() {
-		if (_vspace != null) {
-			return _vspace;
-		}
-
-		_vspace = _iFramePortletInstanceConfiguration.vspace();
-
-		return _vspace;
-	}
-
-	public String getWidth() {
-		if (_width != null) {
-			return _width;
-		}
-
-		_width = _iFramePortletInstanceConfiguration.width();
-
-		return _width;
-	}
-
-	public boolean isAuth() {
-		if (_auth != null) {
-			return _auth;
-		}
-
-		_auth = _iFramePortletInstanceConfiguration.auth();
-
-		return _auth;
-	}
-
-	public boolean isRelative() {
-		if (_relative != null) {
-			return _relative;
-		}
-
-		_relative = _iFramePortletInstanceConfiguration.relative();
-
-		return _relative;
-	}
-
-	public boolean isResizeAutomatically() {
-		if (_resizeAutomatically != null) {
-			return _resizeAutomatically;
-		}
-
-		_resizeAutomatically =
-			_iFramePortletInstanceConfiguration.resizeAutomatically();
-
-		return _resizeAutomatically;
-	}
-
 	private static final String _IFRAME_PREFIX = "iframe_";
 
-	private String _alt;
-	private Boolean _auth;
 	private String _authType;
-	private String _basicPassword;
-	private String _basicUserName;
-	private String _border;
-	private String _bordercolor;
 	private String _formMethod;
-	private String _formPassword;
-	private String _formUserName;
-	private String _frameborder;
 	private String _height;
-	private String _heightMaximized;
-	private String _heightNormal;
 	private String _hiddenVariables;
-	private String _hspace;
 	private String _iFrameBaseSrc;
 	private final IFrameConfiguration _iFrameConfiguration;
 	private final IFramePortletInstanceConfiguration
 		_iFramePortletInstanceConfiguration;
 	private String _iFrameSrc;
-	private String _longdesc;
 	private String _password;
-	private String _passwordField;
-	private Boolean _relative;
 	private final PortletRequest _request;
-	private Boolean _resizeAutomatically;
-	private String _scrolling;
-	private String _src;
 	private final ThemeDisplay _themeDisplay;
-	private String _title;
 	private String _userName;
-	private String _userNameField;
-	private String _vspace;
-	private String _width;
 
 }

--- a/modules/apps/iframe/iframe-web/src/com/liferay/iframe/web/portlet/IFramePortlet.java
+++ b/modules/apps/iframe/iframe-web/src/com/liferay/iframe/web/portlet/IFramePortlet.java
@@ -17,6 +17,7 @@ package com.liferay.iframe.web.portlet;
 import aQute.bnd.annotation.metatype.Configurable;
 
 import com.liferay.iframe.web.configuration.IFrameConfiguration;
+import com.liferay.iframe.web.configuration.IFramePortletInstanceConfiguration;
 import com.liferay.iframe.web.constants.IFrameWebKeys;
 import com.liferay.iframe.web.display.context.IFrameDisplayContext;
 import com.liferay.iframe.web.upgrade.IFrameWebUpgrade;
@@ -121,10 +122,13 @@ public class IFramePortlet extends MVCPortlet {
 		IFrameDisplayContext iFrameDisplayContext = new IFrameDisplayContext(
 			_iFrameConfiguration, renderRequest);
 
-		String src = ParamUtil.getString(
-			renderRequest, "src", iFrameDisplayContext.getSrc());
+		IFramePortletInstanceConfiguration iFramePortletInstanceConfiguration =
+			iFrameDisplayContext.getIFramePortletInstanceConfiguration();
 
-		if (!iFrameDisplayContext.isAuth()) {
+		String src = ParamUtil.getString(
+			renderRequest, "src", iFramePortletInstanceConfiguration.src());
+
+		if (!iFramePortletInstanceConfiguration.auth()) {
 			return src;
 		}
 
@@ -132,9 +136,11 @@ public class IFramePortlet extends MVCPortlet {
 
 		if (authType.equals("basic")) {
 			String userName = IFrameUtil.getUserName(
-				renderRequest, iFrameDisplayContext.getBasicUserName());
+				renderRequest,
+				iFramePortletInstanceConfiguration.basicUserName());
 			String password = IFrameUtil.getPassword(
-				renderRequest, iFrameDisplayContext.getBasicPassword());
+				renderRequest,
+				iFramePortletInstanceConfiguration.basicPassword());
 
 			int pos = src.indexOf("://");
 

--- a/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/settings/internal/NestedPortletsPortletInstanceConfigurationBeanDeclaration.java
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/settings/internal/NestedPortletsPortletInstanceConfigurationBeanDeclaration.java
@@ -12,11 +12,10 @@
  * details.
  */
 
-package com.liferay.nested.portlets.web.configuration.internal;
+package com.liferay.nested.portlets.web.settings.internal;
 
 import com.liferay.nested.portlets.web.configuration.NestedPortletsPortletInstanceConfiguration;
-import com.liferay.nested.portlets.web.constants.NestedPortletsPortletKeys;
-import com.liferay.portal.kernel.settings.definition.SettingsIdMapping;
+import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -24,17 +23,12 @@ import org.osgi.service.component.annotations.Component;
  * @author Juergen Kappler
  */
 @Component
-public class NestedPortletsPortletInstanceSettingsIdMapping
-	implements SettingsIdMapping {
+public class NestedPortletsPortletInstanceConfigurationBeanDeclaration
+	implements ConfigurationBeanDeclaration {
 
 	@Override
-	public Class<?> getConfigurationBeanClass() {
+	public Class getConfigurationBeanClass() {
 		return NestedPortletsPortletInstanceConfiguration.class;
-	}
-
-	@Override
-	public String getSettingsId() {
-		return NestedPortletsPortletKeys.NESTED_PORTLETS;
 	}
 
 }

--- a/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/settings/internal/NestedPortletsPortletInstanceConfigurationBeanDeclaration.java
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/settings/internal/NestedPortletsPortletInstanceConfigurationBeanDeclaration.java
@@ -27,7 +27,7 @@ public class NestedPortletsPortletInstanceConfigurationBeanDeclaration
 	implements ConfigurationBeanDeclaration {
 
 	@Override
-	public Class getConfigurationBeanClass() {
+	public Class<?> getConfigurationBeanClass() {
 		return NestedPortletsPortletInstanceConfiguration.class;
 	}
 

--- a/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/settings/internal/NestedPortletsPortletInstanceSettingsIdMapping.java
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/settings/internal/NestedPortletsPortletInstanceSettingsIdMapping.java
@@ -12,10 +12,11 @@
  * details.
  */
 
-package com.liferay.nested.portlets.web.configuration.internal;
+package com.liferay.nested.portlets.web.settings.internal;
 
 import com.liferay.nested.portlets.web.configuration.NestedPortletsPortletInstanceConfiguration;
-import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
+import com.liferay.nested.portlets.web.constants.NestedPortletsPortletKeys;
+import com.liferay.portal.kernel.settings.definition.SettingsIdMapping;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -23,12 +24,17 @@ import org.osgi.service.component.annotations.Component;
  * @author Juergen Kappler
  */
 @Component
-public class NestedPortletsPortletInstanceConfigurationBeanDeclaration
-	implements ConfigurationBeanDeclaration {
+public class NestedPortletsPortletInstanceSettingsIdMapping
+	implements SettingsIdMapping {
 
 	@Override
-	public Class getConfigurationBeanClass() {
+	public Class<?> getConfigurationBeanClass() {
 		return NestedPortletsPortletInstanceConfiguration.class;
+	}
+
+	@Override
+	public String getSettingsId() {
+		return NestedPortletsPortletKeys.NESTED_PORTLETS;
 	}
 
 }

--- a/modules/apps/rss/rss-web/src/META-INF/resources/configuration.jsp
+++ b/modules/apps/rss/rss-web/src/META-INF/resources/configuration.jsp
@@ -49,14 +49,14 @@
 			<aui:fieldset cssClass="subscriptions">
 
 				<%
-				String[] urls = rssDisplayContext.getUrls();
+				String[] urls = rssPortletInstanceConfiguration.urls();
 
 				if (urls.length == 0) {
 					urls = new String[1];
 					urls[0] = StringPool.BLANK;
 				}
 
-				String[] titles = rssDisplayContext.getTitles();
+				String[] titles = rssPortletInstanceConfiguration.titles();
 
 				for (int i = 0; i < urls.length; i++) {
 					String title = StringPool.BLANK;
@@ -86,7 +86,7 @@
 				<div class="display-template">
 					<liferay-ui:ddm-template-selector
 						className="<%= RSSFeed.class.getName() %>"
-						displayStyle="<%= rssDisplayContext.getDisplayStyle() %>"
+						displayStyle="<%= rssPortletInstanceConfiguration.displayStyle() %>"
 						displayStyleGroupId="<%= rssDisplayContext.getDisplayStyleGroupId() %>"
 						label="display-template"
 						refreshURL="<%= configurationRenderURL.toString() %>"
@@ -94,19 +94,19 @@
 					/>
 				</div>
 
-				<aui:input name="preferences--showFeedTitle--" type="checkbox" value="<%= rssDisplayContext.isShowFeedTitle() %>" />
+				<aui:input name="preferences--showFeedTitle--" type="checkbox" value="<%= rssPortletInstanceConfiguration.showFeedTitle() %>" />
 
-				<aui:input name="preferences--showFeedPublishedDate--" type="checkbox" value="<%= rssDisplayContext.isShowFeedPublishedDate() %>" />
+				<aui:input name="preferences--showFeedPublishedDate--" type="checkbox" value="<%= rssPortletInstanceConfiguration.showFeedPublishedDate() %>" />
 
-				<aui:input name="preferences--showFeedDescription--" type="checkbox" value="<%= rssDisplayContext.isShowFeedDescription() %>" />
+				<aui:input name="preferences--showFeedDescription--" type="checkbox" value="<%= rssPortletInstanceConfiguration.showFeedDescription() %>" />
 
 				<%
 				String taglibShowFeedImageOnClick = "if (this.checked) {document." + renderResponse.getNamespace() + "fm." + renderResponse.getNamespace() + "feedImageAlignment.disabled = '';} else {document." + renderResponse.getNamespace() + "fm." + renderResponse.getNamespace() + "feedImageAlignment.disabled = 'disabled';}";
 				%>
 
-				<aui:input name="preferences--showFeedImage--" onClick="<%= taglibShowFeedImageOnClick %>" type="checkbox" value="<%= rssDisplayContext.isShowFeedImage() %>" />
+				<aui:input name="preferences--showFeedImage--" onClick="<%= taglibShowFeedImageOnClick %>" type="checkbox" value="<%= rssPortletInstanceConfiguration.showFeedImage() %>" />
 
-				<aui:input name="preferences--showFeedItemAuthor--" type="checkbox" value="<%= rssDisplayContext.isShowFeedItemAuthor() %>" />
+				<aui:input name="preferences--showFeedItemAuthor--" type="checkbox" value="<%= rssPortletInstanceConfiguration.showFeedItemAuthor() %>" />
 
 				<aui:select label="num-of-entries-per-feed" name="preferences--entriesPerFeed--">
 
@@ -114,7 +114,7 @@
 					for (int i = 1; i < 10; i++) {
 					%>
 
-						<aui:option label="<%= i %>" selected="<%= i == rssDisplayContext.getEntriesPerFeed() %>" />
+						<aui:option label="<%= i %>" selected="<%= i == rssPortletInstanceConfiguration.entriesPerFeed() %>" />
 
 					<%
 					}
@@ -128,7 +128,7 @@
 					for (int i = 0; i < 10; i++) {
 					%>
 
-						<aui:option label="<%= i %>" selected="<%= i == rssDisplayContext.getExpandedEntriesPerFeed() %>" />
+						<aui:option label="<%= i %>" selected="<%= i == rssPortletInstanceConfiguration.expandedEntriesPerFeed() %>" />
 
 					<%
 					}
@@ -136,9 +136,9 @@
 
 				</aui:select>
 
-				<aui:select disabled="<%= !rssDisplayContext.isShowFeedImage() %>" name="preferences--feedImageAlignment--">
-					<aui:option label="left" selected='<%= rssDisplayContext.getFeedImageAlignment().equals("left") %>' />
-					<aui:option label="right" selected='<%= rssDisplayContext.getFeedImageAlignment().equals("right") %>' />
+				<aui:select disabled="<%= !rssPortletInstanceConfiguration.showFeedImage() %>" name="preferences--feedImageAlignment--">
+					<aui:option label="left" selected='<%= rssPortletInstanceConfiguration.feedImageAlignment().equals("left") %>' />
+					<aui:option label="right" selected='<%= rssPortletInstanceConfiguration.feedImageAlignment().equals("right") %>' />
 				</aui:select>
 			</aui:fieldset>
 		</liferay-ui:panel>

--- a/modules/apps/rss/rss-web/src/META-INF/resources/feed.jspf
+++ b/modules/apps/rss/rss-web/src/META-INF/resources/feed.jspf
@@ -22,19 +22,19 @@
 			SyndImage syndImage = syndFeed.getImage();
 			%>
 
-			<c:if test="<%= (syndImage != null) && rssDisplayContext.isShowFeedImage() %>">
+			<c:if test="<%= (syndImage != null) && rssPortletInstanceConfiguration.showFeedImage() %>">
 				<div class="feed-image">
 					<img alt="<%= HtmlUtil.escapeAttribute(syndImage.getDescription()) %>" src="<%= HtmlUtil.escapeHREF(rssFeed.getSyndFeedImageURL()) %>" />
 				</div>
 			</c:if>
 
-			<c:if test="<%= rssDisplayContext.isShowFeedTitle() %>">
+			<c:if test="<%= rssPortletInstanceConfiguration.showFeedTitle() %>">
 				<div class="feed-title">
 					<aui:a href="<%= HtmlUtil.escapeJSLink(rssFeed.getSyndFeedLink()) %>" target="_blank"><%= HtmlUtil.escape(rssFeed.getTitle()) %></aui:a>
 				</div>
 			</c:if>
 
-			<c:if test="<%= (syndFeed.getPublishedDate() != null) && rssDisplayContext.isShowFeedDescription() %>">
+			<c:if test="<%= (syndFeed.getPublishedDate() != null) && rssPortletInstanceConfiguration.showFeedDescription() %>">
 				<div class="feed-date feed-published-date">
 					<liferay-ui:icon
 						iconCssClass="icon-calendar"
@@ -44,7 +44,7 @@
 				</div>
 			</c:if>
 
-			<c:if test="<%= Validator.isNotNull(syndFeed.getDescription()) && rssDisplayContext.isShowFeedDescription() %>">
+			<c:if test="<%= Validator.isNotNull(syndFeed.getDescription()) && rssPortletInstanceConfiguration.showFeedDescription() %>">
 				<div class="feed-description">
 					<%= HtmlUtil.escape(syndFeed.getDescription()) %>
 				</div>
@@ -58,15 +58,15 @@
 				<liferay-ui:panel-container cssClass="feed-entries" extended="<%= false %>" id="rssFeedsPanelContainer" persistState="<%= false %>">
 
 					<%
-					for (int j = 0; (j < rssFeedEntryDisplayContexts.size()) && (j < rssDisplayContext.getEntriesPerFeed()); j++) {
+					for (int j = 0; (j < rssFeedEntryDisplayContexts.size()) && (j < rssPortletInstanceConfiguration.entriesPerFeed()); j++) {
 						RSSFeedEntry rssFeedEntry = rssFeedEntryDisplayContexts.get(j);
 
 						SyndEntry syndEntry = rssFeedEntry.getSyndEntry();
 					%>
 
-						<liferay-ui:panel cssClass="feed-entry" defaultState='<%= (themeDisplay.isStateMaximized() || (j < rssDisplayContext.getExpandedEntriesPerFeed())) ? "open" : "closed" %>' extended="<%= false%>" title="<%= HtmlUtil.escape(syndEntry.getTitle()) %>">
+						<liferay-ui:panel cssClass="feed-entry" defaultState='<%= (themeDisplay.isStateMaximized() || (j < rssPortletInstanceConfiguration.expandedEntriesPerFeed())) ? "open" : "closed" %>' extended="<%= false%>" title="<%= HtmlUtil.escape(syndEntry.getTitle()) %>">
 							<div class="feed-entry-content">
-								<c:if test="<%= rssDisplayContext.isShowFeedItemAuthor() && Validator.isNotNull(syndEntry.getAuthor()) %>">
+								<c:if test="<%= rssPortletInstanceConfiguration.showFeedItemAuthor() && Validator.isNotNull(syndEntry.getAuthor()) %>">
 									<div class="feed-entry-author">
 										<%= HtmlUtil.escape(syndEntry.getAuthor()) %>
 									</div>

--- a/modules/apps/rss/rss-web/src/META-INF/resources/init.jsp
+++ b/modules/apps/rss/rss-web/src/META-INF/resources/init.jsp
@@ -28,6 +28,7 @@ page import="com.liferay.portal.kernel.util.FastDateFormatFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringPool" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
+page import="com.liferay.rss.web.configuration.RSSPortletInstanceConfiguration" %><%@
 page import="com.liferay.rss.web.configuration.RSSWebConfiguration" %><%@
 page import="com.liferay.rss.web.display.context.RSSDisplayContext" %><%@
 page import="com.liferay.rss.web.util.RSSFeed" %><%@
@@ -51,6 +52,8 @@ page import="java.util.List" %>
 RSSWebConfiguration rssWebConfiguration = (RSSWebConfiguration)renderRequest.getAttribute(RSSWebConfiguration.class.getName());
 
 RSSDisplayContext rssDisplayContext = new RSSDisplayContext(request, rssWebConfiguration);
+
+RSSPortletInstanceConfiguration rssPortletInstanceConfiguration = rssDisplayContext.getRSSPortletInstanceConfiguration();
 
 Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 %>

--- a/modules/apps/rss/rss-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/rss/rss-web/src/META-INF/resources/view.jsp
@@ -20,7 +20,7 @@
 List<RSSFeed> rssFeeds = rssDisplayContext.getRSSFeeds();
 %>
 
-<liferay-ui:ddm-template-renderer className="<%= RSSFeed.class.getName() %>" displayStyle="<%= rssDisplayContext.getDisplayStyle() %>" displayStyleGroupId="<%= rssDisplayContext.getDisplayStyleGroupId() %>" entries="<%= rssFeeds %>">
+<liferay-ui:ddm-template-renderer className="<%= RSSFeed.class.getName() %>" displayStyle="<%= rssPortletInstanceConfiguration.displayStyle() %>" displayStyleGroupId="<%= rssDisplayContext.getDisplayStyleGroupId() %>" entries="<%= rssFeeds %>">
 
 	<%
 	for (int i = 0; i < rssFeeds.size(); i++) {

--- a/modules/apps/rss/rss-web/src/com/liferay/rss/web/display/context/RSSDisplayContext.java
+++ b/modules/apps/rss/rss-web/src/com/liferay/rss/web/display/context/RSSDisplayContext.java
@@ -50,16 +50,6 @@ public class RSSDisplayContext {
 				RSSPortletInstanceConfiguration.class);
 	}
 
-	public String getDisplayStyle() {
-		if (_displayStyle != null) {
-			return _displayStyle;
-		}
-
-		_displayStyle = _rssPortletInstanceConfiguration.displayStyle();
-
-		return _displayStyle;
-	}
-
 	public long getDisplayStyleGroupId() {
 		if (_displayStyleGroupId != 0) {
 			return _displayStyleGroupId;
@@ -76,38 +66,6 @@ public class RSSDisplayContext {
 		}
 
 		return _displayStyleGroupId;
-	}
-
-	public int getEntriesPerFeed() {
-		if (_entriesPerFeed != null) {
-			return _entriesPerFeed;
-		}
-
-		_entriesPerFeed = _rssPortletInstanceConfiguration.entriesPerFeed();
-
-		return _entriesPerFeed;
-	}
-
-	public int getExpandedEntriesPerFeed() {
-		if (_expandedEntriesPerFeed != null) {
-			return _expandedEntriesPerFeed;
-		}
-
-		_expandedEntriesPerFeed =
-			_rssPortletInstanceConfiguration.expandedEntriesPerFeed();
-
-		return _expandedEntriesPerFeed;
-	}
-
-	public String getFeedImageAlignment() {
-		if (_feedImageAlignment != null) {
-			return _feedImageAlignment;
-		}
-
-		_feedImageAlignment =
-			_rssPortletInstanceConfiguration.feedImageAlignment();
-
-		return _feedImageAlignment;
 	}
 
 	public List<RSSFeed> getRSSFeeds() {
@@ -132,80 +90,16 @@ public class RSSDisplayContext {
 		return rssFeeds;
 	}
 
-	public String[] getTitles() {
-		return _rssPortletInstanceConfiguration.titles();
+	public RSSPortletInstanceConfiguration
+		getRSSPortletInstanceConfiguration() {
+
+		return _rssPortletInstanceConfiguration;
 	}
 
-	public String[] getUrls() {
-		return _rssPortletInstanceConfiguration.urls();
-	}
-
-	public boolean isShowFeedDescription() {
-		if (_showFeedDescription != null) {
-			return _showFeedDescription;
-		}
-
-		_showFeedDescription =
-			_rssPortletInstanceConfiguration.showFeedDescription();
-
-		return _showFeedDescription;
-	}
-
-	public boolean isShowFeedImage() {
-		if (_showFeedImage != null) {
-			return _showFeedImage;
-		}
-
-		_showFeedImage = _rssPortletInstanceConfiguration.showFeedImage();
-
-		return _showFeedImage;
-	}
-
-	public boolean isShowFeedItemAuthor() {
-		if (_showFeedItemAuthor != null) {
-			return _showFeedItemAuthor;
-		}
-
-		_showFeedItemAuthor =
-			_rssPortletInstanceConfiguration.showFeedItemAuthor();
-
-		return _showFeedItemAuthor;
-	}
-
-	public boolean isShowFeedPublishedDate() {
-		if (_showFeedPublishedDate != null) {
-			return _showFeedPublishedDate;
-		}
-
-		_showFeedPublishedDate =
-			_rssPortletInstanceConfiguration.showFeedPublishedDate();
-
-		return _showFeedPublishedDate;
-	}
-
-	public boolean isShowFeedTitle() {
-		if (_showFeedTitle != null) {
-			return _showFeedTitle;
-		}
-
-		_showFeedTitle = _rssPortletInstanceConfiguration.showFeedTitle();
-
-		return _showFeedTitle;
-	}
-
-	private String _displayStyle;
 	private long _displayStyleGroupId;
-	private Integer _entriesPerFeed;
-	private Integer _expandedEntriesPerFeed;
-	private String _feedImageAlignment;
 	private final HttpServletRequest _request;
 	private final RSSPortletInstanceConfiguration
 		_rssPortletInstanceConfiguration;
 	private final RSSWebConfiguration _rssWebConfiguration;
-	private Boolean _showFeedDescription;
-	private Boolean _showFeedImage;
-	private Boolean _showFeedItemAuthor;
-	private Boolean _showFeedPublishedDate;
-	private Boolean _showFeedTitle;
 
 }

--- a/modules/apps/rss/rss-web/src/com/liferay/rss/web/settings/internal/RSSPortletInstanceConfigurationBeanDeclaration.java
+++ b/modules/apps/rss/rss-web/src/com/liferay/rss/web/settings/internal/RSSPortletInstanceConfigurationBeanDeclaration.java
@@ -27,7 +27,7 @@ public class RSSPortletInstanceConfigurationBeanDeclaration
 	implements ConfigurationBeanDeclaration {
 
 	@Override
-	public Class getConfigurationBeanClass() {
+	public Class<?> getConfigurationBeanClass() {
 		return RSSPortletInstanceConfiguration.class;
 	}
 

--- a/modules/apps/site-navigation/site-navigation-breadcrumb-web/src/com/liferay/site/navigation/breadcrumb/web/settings/internal/BreadcrumbPortletInstanceConfigurationBeanDeclaration.java
+++ b/modules/apps/site-navigation/site-navigation-breadcrumb-web/src/com/liferay/site/navigation/breadcrumb/web/settings/internal/BreadcrumbPortletInstanceConfigurationBeanDeclaration.java
@@ -27,7 +27,7 @@ public class BreadcrumbPortletInstanceConfigurationBeanDeclaration
 	implements ConfigurationBeanDeclaration {
 
 	@Override
-	public Class getConfigurationBeanClass() {
+	public Class<?> getConfigurationBeanClass() {
 		return BreadcrumbPortletInstanceConfiguration.class;
 	}
 

--- a/modules/apps/site-navigation/site-navigation-directory-web/src/com/liferay/site/navigation/directory/web/settings/internal/SitesDirectoryPortletInstanceConfigurationBeanDeclaration.java
+++ b/modules/apps/site-navigation/site-navigation-directory-web/src/com/liferay/site/navigation/directory/web/settings/internal/SitesDirectoryPortletInstanceConfigurationBeanDeclaration.java
@@ -27,7 +27,7 @@ public class SitesDirectoryPortletInstanceConfigurationBeanDeclaration
 	implements ConfigurationBeanDeclaration {
 
 	@Override
-	public Class getConfigurationBeanClass() {
+	public Class<?> getConfigurationBeanClass() {
 		return SitesDirectoryPortletInstanceConfiguration.class;
 	}
 

--- a/modules/apps/site-navigation/site-navigation-language-web/src/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/META-INF/resources/configuration.jsp
@@ -42,14 +42,14 @@
 		<div class="display-template">
 			<liferay-ui:ddm-template-selector
 				className="<%= LanguageEntry.class.getName() %>"
-				displayStyle="<%= languageDisplayContext.getDisplayStyle() %>"
+				displayStyle="<%= languagePortletInstanceConfiguration.displayStyle() %>"
 				displayStyleGroupId="<%= languageDisplayContext.getDisplayStyleGroupId() %>"
 				refreshURL="<%= configurationRenderURL %>"
 			/>
 		</div>
 	</aui:fieldset>
 
-	<aui:input name="preferences--displayCurrentLocale--" type="checkbox" value="<%= languageDisplayContext.isDisplayCurrentLocale() %>" />
+	<aui:input name="preferences--displayCurrentLocale--" type="checkbox" value="<%= languagePortletInstanceConfiguration.displayCurrentLocale() %>" />
 
 	<aui:button-row>
 		<aui:button type="submit" />

--- a/modules/apps/site-navigation/site-navigation-language-web/src/META-INF/resources/init.jsp
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/META-INF/resources/init.jsp
@@ -23,6 +23,7 @@
 
 <%@ page import="com.liferay.portal.kernel.servlet.taglib.ui.LanguageEntry" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
+page import="com.liferay.site.navigation.language.web.configuration.LanguagePortletInstanceConfiguration" %><%@
 page import="com.liferay.site.navigation.language.web.display.context.LanguageDisplayContext" %>
 
 <liferay-theme:defineObjects />
@@ -30,6 +31,8 @@ page import="com.liferay.site.navigation.language.web.display.context.LanguageDi
 
 <%
 LanguageDisplayContext languageDisplayContext = new LanguageDisplayContext(request);
+
+LanguagePortletInstanceConfiguration languagePortletInstanceConfiguration = languageDisplayContext.getLanguagePortletInstanceConfiguration();
 %>
 
 <%@ include file="/init-ext.jsp" %>

--- a/modules/apps/site-navigation/site-navigation-language-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/META-INF/resources/view.jsp
@@ -19,7 +19,7 @@
 <liferay-ui:language
 	ddmTemplateGroupId="<%= languageDisplayContext.getDisplayStyleGroupId() %>"
 	ddmTemplateKey="<%= languageDisplayContext.getDDMTemplateKey() %>"
-	displayCurrentLocale="<%= languageDisplayContext.isDisplayCurrentLocale() %>"
+	displayCurrentLocale="<%= languagePortletInstanceConfiguration.displayCurrentLocale() %>"
 	languageIds="<%= languageDisplayContext.getLanguageIds() %>"
 	useNamespace="<%= false %>"
 />

--- a/modules/apps/site-navigation/site-navigation-language-web/src/com/liferay/site/navigation/language/web/display/context/LanguageDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/com/liferay/site/navigation/language/web/display/context/LanguageDisplayContext.java
@@ -115,7 +115,8 @@ public class LanguageDisplayContext {
 			return _ddmTemplateKey;
 		}
 
-		String displayStyle = getDisplayStyle();
+		String displayStyle =
+			_languagePortletInstanceConfiguration.displayStyle();
 
 		if (displayStyle != null) {
 			_ddmTemplateKey = PortletDisplayTemplateUtil.getDDMTemplateKey(
@@ -123,16 +124,6 @@ public class LanguageDisplayContext {
 		}
 
 		return _ddmTemplateKey;
-	}
-
-	public String getDisplayStyle() {
-		if (_displayStyle != null) {
-			return _displayStyle;
-		}
-
-		_displayStyle = _languagePortletInstanceConfiguration.displayStyle();
-
-		return _displayStyle;
 	}
 
 	public long getDisplayStyleGroupId() {
@@ -165,21 +156,14 @@ public class LanguageDisplayContext {
 		return _languageIds;
 	}
 
-	public boolean isDisplayCurrentLocale() {
-		if (_displayCurrentLocale != null) {
-			return _displayCurrentLocale;
-		}
+	public LanguagePortletInstanceConfiguration
+		getLanguagePortletInstanceConfiguration() {
 
-		_displayCurrentLocale =
-			_languagePortletInstanceConfiguration.displayCurrentLocale();
-
-		return _displayCurrentLocale;
+		return _languagePortletInstanceConfiguration;
 	}
 
 	private String[] _availableLanguageIds;
 	private String _ddmTemplateKey;
-	private Boolean _displayCurrentLocale;
-	private String _displayStyle;
 	private long _displayStyleGroupId;
 	private String[] _languageIds;
 	private final LanguagePortletInstanceConfiguration

--- a/modules/apps/site-navigation/site-navigation-language-web/src/com/liferay/site/navigation/language/web/settings/internal/LanguagePortletInstanceConfigurationBeanDeclaration.java
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/com/liferay/site/navigation/language/web/settings/internal/LanguagePortletInstanceConfigurationBeanDeclaration.java
@@ -27,7 +27,7 @@ public class LanguagePortletInstanceConfigurationBeanDeclaration
 	implements ConfigurationBeanDeclaration {
 
 	@Override
-	public Class getConfigurationBeanClass() {
+	public Class<?> getConfigurationBeanClass() {
 		return LanguagePortletInstanceConfiguration.class;
 	}
 

--- a/modules/apps/site-navigation/site-navigation-site-map-web/src/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-site-map-web/src/META-INF/resources/configuration.jsp
@@ -39,7 +39,7 @@ List<LayoutDescription> layoutDescriptions = siteMapDisplayContext.getLayoutDesc
 				if (layoutDescriptionLayout != null) {
 			%>
 
-				<aui:option label="<%= layoutDescription.getDisplayName() %>" selected="<%= Validator.equals(layoutDescriptionLayout.getUuid(), siteMapDisplayContext.getRootLayoutUuid()) %>" value="<%= layoutDescriptionLayout.getUuid() %>" />
+				<aui:option label="<%= layoutDescription.getDisplayName() %>" selected="<%= Validator.equals(layoutDescriptionLayout.getUuid(), siteMapPortletInstanceConfiguration.rootLayoutUuid()) %>" value="<%= layoutDescriptionLayout.getUuid() %>" />
 
 			<%
 				}
@@ -55,7 +55,7 @@ List<LayoutDescription> layoutDescriptions = siteMapDisplayContext.getLayoutDesc
 			for (int i = 1; i <= 20; i++) {
 			%>
 
-				<aui:option label="<%= i %>" selected="<%= siteMapDisplayContext.getDisplayDepth() == i %>" />
+				<aui:option label="<%= i %>" selected="<%= siteMapPortletInstanceConfiguration.displayDepth() == i %>" />
 
 			<%
 			}
@@ -65,16 +65,16 @@ List<LayoutDescription> layoutDescriptions = siteMapDisplayContext.getLayoutDesc
 
 		<aui:input name="preferences--includeRootInTree--" type="checkbox" value="<%= siteMapDisplayContext.isIncludeRootInTree() %>" />
 
-		<aui:input name="preferences--showCurrentPage--" type="checkbox" value="<%= siteMapDisplayContext.isShowCurrentPage() %>" />
+		<aui:input name="preferences--showCurrentPage--" type="checkbox" value="<%= siteMapPortletInstanceConfiguration.showCurrentPage() %>" />
 
-		<aui:input name="preferences--useHtmlTitle--" type="checkbox" value="<%= siteMapDisplayContext.isUseHtmlTitle() %>" />
+		<aui:input name="preferences--useHtmlTitle--" type="checkbox" value="<%= siteMapPortletInstanceConfiguration.useHtmlTitle() %>" />
 
-		<aui:input name="preferences--showHiddenPages--" type="checkbox" value="<%= siteMapDisplayContext.isShowHiddenPages() %>" />
+		<aui:input name="preferences--showHiddenPages--" type="checkbox" value="<%= siteMapPortletInstanceConfiguration.showHiddenPages() %>" />
 
 		<div class="display-template">
 			<liferay-ui:ddm-template-selector
 				className="<%= LayoutSet.class.getName() %>"
-				displayStyle="<%= siteMapDisplayContext.getDisplayStyle() %>"
+				displayStyle="<%= siteMapPortletInstanceConfiguration.displayStyle() %>"
 				displayStyleGroupId="<%= siteMapDisplayContext.getDisplayStyleGroupId() %>"
 				refreshURL="<%= configurationRenderURL %>"
 				showEmptyOption="<%= true %>"

--- a/modules/apps/site-navigation/site-navigation-site-map-web/src/META-INF/resources/init.jsp
+++ b/modules/apps/site-navigation/site-navigation-site-map-web/src/META-INF/resources/init.jsp
@@ -27,6 +27,7 @@ page import="com.liferay.portal.model.Layout" %><%@
 page import="com.liferay.portal.model.LayoutSet" %><%@
 page import="com.liferay.portal.service.LayoutLocalServiceUtil" %><%@
 page import="com.liferay.portal.util.LayoutDescription" %><%@
+page import="com.liferay.site.navigation.site.map.web.configuration.SiteMapPortletInstanceConfiguration" %><%@
 page import="com.liferay.site.navigation.site.map.web.display.context.SiteMapDisplayContext" %>
 
 <%@ page import="java.util.List" %>
@@ -36,6 +37,8 @@ page import="com.liferay.site.navigation.site.map.web.display.context.SiteMapDis
 
 <%
 SiteMapDisplayContext siteMapDisplayContext = new SiteMapDisplayContext(request);
+
+SiteMapPortletInstanceConfiguration siteMapPortletInstanceConfiguration = siteMapDisplayContext.getSiteMapPortletInstanceConfiguration();
 %>
 
 <%@ include file="/init-ext.jsp" %>

--- a/modules/apps/site-navigation/site-navigation-site-map-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/site-navigation/site-navigation-site-map-web/src/META-INF/resources/view.jsp
@@ -16,6 +16,6 @@
 
 <%@ include file="/init.jsp" %>
 
-<liferay-ui:ddm-template-renderer className="<%= LayoutSet.class.getName() %>" displayStyle="<%= siteMapDisplayContext.getDisplayStyle() %>" displayStyleGroupId="<%= siteMapDisplayContext.getDisplayStyleGroupId() %>" entries="<%= siteMapDisplayContext.getRootLayouts() %>">
+<liferay-ui:ddm-template-renderer className="<%= LayoutSet.class.getName() %>" displayStyle="<%= siteMapPortletInstanceConfiguration.displayStyle() %>" displayStyleGroupId="<%= siteMapDisplayContext.getDisplayStyleGroupId() %>" entries="<%= siteMapDisplayContext.getRootLayouts() %>">
 	<%= siteMapDisplayContext.buildSiteMap() %>
 </liferay-ui:ddm-template-renderer>

--- a/modules/apps/site-navigation/site-navigation-site-map-web/src/com/liferay/site/navigation/site/map/web/display/context/SiteMapDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-site-map-web/src/com/liferay/site/navigation/site/map/web/display/context/SiteMapDisplayContext.java
@@ -61,30 +61,14 @@ public class SiteMapDisplayContext {
 
 		_buildSiteMap(
 			_themeDisplay.getLayout(), getRootLayouts(), getRootLayout(),
-			isIncludeRootInTree(), getDisplayDepth(), isShowCurrentPage(),
-			isUseHtmlTitle(), isShowHiddenPages(), 1, _themeDisplay, sb);
+			isIncludeRootInTree(),
+			_siteMapPortletInstanceConfiguration.displayDepth(),
+			_siteMapPortletInstanceConfiguration.showCurrentPage(),
+			_siteMapPortletInstanceConfiguration.useHtmlTitle(),
+			_siteMapPortletInstanceConfiguration.showHiddenPages(), 1,
+			_themeDisplay, sb);
 
 		return sb.toString();
-	}
-
-	public Integer getDisplayDepth() {
-		if (_displayDepth != null) {
-			return _displayDepth;
-		}
-
-		_displayDepth = _siteMapPortletInstanceConfiguration.displayDepth();
-
-		return _displayDepth;
-	}
-
-	public String getDisplayStyle() {
-		if (_displayStyle != null) {
-			return _displayStyle;
-		}
-
-		_displayStyle = _siteMapPortletInstanceConfiguration.displayStyle();
-
-		return _displayStyle;
 	}
 
 	public Long getDisplayStyleGroupId() {
@@ -117,11 +101,14 @@ public class SiteMapDisplayContext {
 			return _rootLayout;
 		}
 
-		if (Validator.isNotNull(getRootLayoutUuid())) {
+		String rootLayoutUuid =
+			_siteMapPortletInstanceConfiguration.rootLayoutUuid();
+
+		if (Validator.isNotNull(rootLayoutUuid)) {
 			Layout layout = _themeDisplay.getLayout();
 
 			_rootLayout = LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
-				getRootLayoutUuid(), _themeDisplay.getScopeGroupId(),
+				rootLayoutUuid, _themeDisplay.getScopeGroupId(),
 				layout.isPrivateLayout());
 		}
 
@@ -135,7 +122,8 @@ public class SiteMapDisplayContext {
 
 		Layout rootLayout = getRootLayout();
 
-		if (Validator.isNotNull(getRootLayoutUuid()) &&
+		if (Validator.isNotNull(
+				_siteMapPortletInstanceConfiguration.rootLayoutUuid()) &&
 			Validator.isNotNull(rootLayout)) {
 
 			_rootLayoutId = rootLayout.getLayoutId();
@@ -154,14 +142,10 @@ public class SiteMapDisplayContext {
 			layout.getGroupId(), layout.isPrivateLayout(), getRootLayoutId());
 	}
 
-	public String getRootLayoutUuid() {
-		if (_rootLayoutUuid != null) {
-			return _rootLayoutUuid;
-		}
+	public SiteMapPortletInstanceConfiguration
+		getSiteMapPortletInstanceConfiguration() {
 
-		_rootLayoutUuid = _siteMapPortletInstanceConfiguration.rootLayoutUuid();
-
-		return _rootLayoutUuid;
+		return _siteMapPortletInstanceConfiguration;
 	}
 
 	public Boolean isIncludeRootInTree() {
@@ -172,45 +156,14 @@ public class SiteMapDisplayContext {
 		_includeRootInTree =
 			_siteMapPortletInstanceConfiguration.includeRootInTree();
 
-		if (Validator.isNull(getRootLayoutUuid()) ||
+		if (Validator.isNull(
+				_siteMapPortletInstanceConfiguration.rootLayoutUuid()) ||
 			(getRootLayoutId() == LayoutConstants.DEFAULT_PARENT_LAYOUT_ID)) {
 
 			_includeRootInTree = false;
 		}
 
 		return _includeRootInTree;
-	}
-
-	public Boolean isShowCurrentPage() {
-		if (_showCurrentPage != null) {
-			return _showCurrentPage;
-		}
-
-		_showCurrentPage =
-			_siteMapPortletInstanceConfiguration.showCurrentPage();
-
-		return _showCurrentPage;
-	}
-
-	public Boolean isShowHiddenPages() {
-		if (_showHiddenPages != null) {
-			return _showHiddenPages;
-		}
-
-		_showHiddenPages =
-			_siteMapPortletInstanceConfiguration.showHiddenPages();
-
-		return _showHiddenPages;
-	}
-
-	public Boolean isUseHtmlTitle() {
-		if (_useHtmlTitle != null) {
-			return _useHtmlTitle;
-		}
-
-		_useHtmlTitle = _siteMapPortletInstanceConfiguration.useHtmlTitle();
-
-		return _useHtmlTitle;
 	}
 
 	private void _buildLayoutView(
@@ -324,19 +277,13 @@ public class SiteMapDisplayContext {
 		sb.append("</ul>");
 	}
 
-	private Integer _displayDepth;
-	private String _displayStyle;
 	private Long _displayStyleGroupId;
 	private Boolean _includeRootInTree;
 	private final HttpServletRequest _request;
 	private Layout _rootLayout;
 	private Long _rootLayoutId;
-	private String _rootLayoutUuid;
-	private Boolean _showCurrentPage;
-	private Boolean _showHiddenPages;
 	private final SiteMapPortletInstanceConfiguration
 		_siteMapPortletInstanceConfiguration;
 	private final ThemeDisplay _themeDisplay;
-	private Boolean _useHtmlTitle;
 
 }

--- a/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/configuration.jsp
+++ b/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/configuration.jsp
@@ -39,9 +39,9 @@
 	</c:if>
 
 	<aui:fieldset>
-		<aui:input cssClass="lfr-input-text-container" name="preferences--xmlUrl--" type="text" value="<%= xslContentDisplayContext.getXMLUrl() %>" />
+		<aui:input cssClass="lfr-input-text-container" name="preferences--xmlUrl--" type="text" value="<%= xslContentPortletInstanceConfiguration.xmlUrl() %>" />
 
-		<aui:input cssClass="lfr-input-text-container" name="preferences--xslUrl--" type="text" value="<%= xslContentDisplayContext.getXSLUrl() %>" />
+		<aui:input cssClass="lfr-input-text-container" name="preferences--xslUrl--" type="text" value="<%= xslContentPortletInstanceConfiguration.xslUrl() %>" />
 	</aui:fieldset>
 
 	<aui:button-row>

--- a/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/init.jsp
+++ b/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/init.jsp
@@ -26,6 +26,7 @@ page import="com.liferay.portal.kernel.log.LogFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.xsl.content.web.configuration.XSLContentConfiguration" %><%@
+page import="com.liferay.xsl.content.web.configuration.XSLContentPortletInstanceConfiguration" %><%@
 page import="com.liferay.xsl.content.web.display.context.XSLContentDisplayContext" %>
 
 <liferay-theme:defineObjects />
@@ -35,6 +36,8 @@ page import="com.liferay.xsl.content.web.display.context.XSLContentDisplayContex
 XSLContentConfiguration xslContentConfiguration = (XSLContentConfiguration)request.getAttribute(XSLContentConfiguration.class.getName());
 
 XSLContentDisplayContext xslContentDisplayContext = new XSLContentDisplayContext(request, xslContentConfiguration);
+
+XSLContentPortletInstanceConfiguration xslContentPortletInstanceConfiguration = xslContentDisplayContext.getXSLContentPortletInstanceConfiguration();
 %>
 
 <%@ include file="/init-ext.jsp" %>

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/display/context/XSLContentDisplayContext.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/display/context/XSLContentDisplayContext.java
@@ -54,10 +54,10 @@ public class XSLContentDisplayContext {
 		}
 
 		String xmlUrl = XSLContentUtil.replaceUrlTokens(
-			_themeDisplay, getXMLUrl());
+			_themeDisplay, _xslContentPortletInstanceConfiguration.xmlUrl());
 
 		String xslUrl = XSLContentUtil.replaceUrlTokens(
-			_themeDisplay, getXSLUrl());
+			_themeDisplay, _xslContentPortletInstanceConfiguration.xslUrl());
 
 		_content = XSLContentUtil.transform(
 			_xslContentConfiguration, new URL(xmlUrl), new URL(xslUrl));
@@ -65,32 +65,16 @@ public class XSLContentDisplayContext {
 		return _content;
 	}
 
-	public String getXMLUrl() {
-		if (_xmlUrl != null) {
-			return _xmlUrl;
-		}
+	public XSLContentPortletInstanceConfiguration
+		getXSLContentPortletInstanceConfiguration() {
 
-		_xmlUrl = _xslContentPortletInstanceConfiguration.xmlUrl();
-
-		return _xmlUrl;
-	}
-
-	public String getXSLUrl() {
-		if (_xslUrl != null) {
-			return _xslUrl;
-		}
-
-		_xslUrl = _xslContentPortletInstanceConfiguration.xslUrl();
-
-		return _xslUrl;
+		return _xslContentPortletInstanceConfiguration;
 	}
 
 	private String _content;
 	private final ThemeDisplay _themeDisplay;
-	private String _xmlUrl;
 	private final XSLContentConfiguration _xslContentConfiguration;
 	private final XSLContentPortletInstanceConfiguration
 		_xslContentPortletInstanceConfiguration;
-	private String _xslUrl;
 
 }

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/settings/internal/XSLContentPortletInstanceConfigurationBeanDeclaration.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/settings/internal/XSLContentPortletInstanceConfigurationBeanDeclaration.java
@@ -27,7 +27,7 @@ public class XSLContentPortletInstanceConfigurationBeanDeclaration
 	implements ConfigurationBeanDeclaration {
 
 	@Override
-	public Class getConfigurationBeanClass() {
+	public Class<?> getConfigurationBeanClass() {
 		return XSLContentPortletInstanceConfiguration.class;
 	}
 


### PR DESCRIPTION
A new patter was establish for using the configuration values in the view.

We now avoid using getters in the display context class of the module for those values that can be retrieved directly. There is a method in the class, for obtaining the portlet instance configuration, which will be use later to obtain the values that are needed.

For those values with required default values, or that need certain kind of transformation, we create a getter method in the display context class. 

The best example of this are those portlets that have preview in their configuration view. Since the view is being refreshed when the values are being selected, the values have to be obtained from the parameters, and not directly from the configuration. 

