### PR TITLE
[TECHNICAL-SUPPORT] LPS-56553 Cannot modify child Page if it's associated to a Site Template

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -244,17 +244,10 @@ public class LayoutLocalServiceHelper implements IdentifiableBean {
 			}
 		}
 		else {
-
-			// Layout cannot become a child of a layout that is not sortable
-			// because it is linked to a layout set prototype
-
 			Layout parentLayout = layoutPersistence.findByG_P_L(
 				groupId, privateLayout, parentLayoutId);
 
-			if (!SitesUtil.isLayoutSortable(parentLayout)) {
-				throw new LayoutParentLayoutIdException(
-					LayoutParentLayoutIdException.NOT_SORTABLE);
-			}
+			checkIfParentLayoutIsPrototype(parentLayout);
 		}
 
 		if (firstLayout) {
@@ -494,13 +487,7 @@ public class LayoutLocalServiceHelper implements IdentifiableBean {
 				LayoutParentLayoutIdException.NOT_PARENTABLE);
 		}
 
-		// Layout cannot become a child of a layout that is not sortable because
-		// it is linked to a layout set prototype
-
-		if (!SitesUtil.isLayoutSortable(parentLayout)) {
-			throw new LayoutParentLayoutIdException(
-				LayoutParentLayoutIdException.NOT_SORTABLE);
-		}
+		checkIfParentLayoutIsPrototype(parentLayout);
 
 		// Layout cannot become descendant of itself
 
@@ -535,6 +522,18 @@ public class LayoutLocalServiceHelper implements IdentifiableBean {
 						LayoutParentLayoutIdException.FIRST_LAYOUT_TYPE);
 				}
 			}
+		}
+	}
+
+	protected void checkIfParentLayoutIsPrototype(Layout parentLayout)
+		throws LayoutParentLayoutIdException {
+
+		// Layout cannot become a child of a layout that is not sortable because
+		// it is linked to a layout set prototype
+
+		if (!SitesUtil.isLayoutSortable(parentLayout)) {
+			throw new LayoutParentLayoutIdException(
+				LayoutParentLayoutIdException.NOT_SORTABLE);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -244,10 +244,12 @@ public class LayoutLocalServiceHelper implements IdentifiableBean {
 			}
 		}
 		else {
+			Layout layout = layoutPersistence.findByG_P_L(
+				groupId, privateLayout, layoutId);
 			Layout parentLayout = layoutPersistence.findByG_P_L(
 				groupId, privateLayout, parentLayoutId);
 
-			checkIfParentLayoutIsPrototype(parentLayout);
+			checkIfParentLayoutIsPrototype(layout, parentLayout);
 		}
 
 		if (firstLayout) {
@@ -487,7 +489,7 @@ public class LayoutLocalServiceHelper implements IdentifiableBean {
 				LayoutParentLayoutIdException.NOT_PARENTABLE);
 		}
 
-		checkIfParentLayoutIsPrototype(parentLayout);
+		checkIfParentLayoutIsPrototype(layout, parentLayout);
 
 		// Layout cannot become descendant of itself
 
@@ -525,13 +527,16 @@ public class LayoutLocalServiceHelper implements IdentifiableBean {
 		}
 	}
 
-	protected void checkIfParentLayoutIsPrototype(Layout parentLayout)
+	protected void checkIfParentLayoutIsPrototype(
+			Layout layout, Layout parentLayout)
 		throws LayoutParentLayoutIdException {
 
 		// Layout cannot become a child of a layout that is not sortable because
 		// it is linked to a layout set prototype
 
-		if (!SitesUtil.isLayoutSortable(parentLayout)) {
+		if (Validator.isNull(layout.getSourcePrototypeLayoutUuid()) &&
+			!SitesUtil.isLayoutSortable(parentLayout)) {
+
 			throw new LayoutParentLayoutIdException(
 				LayoutParentLayoutIdException.NOT_SORTABLE);
 		}


### PR DESCRIPTION
Hey Julio,

we have the logic which ensures that a layout which belongs to the Site cannot become a child layout which belongs to a Site Template.

However, this logic doesn't make sense when the child layout is associated to the Template as well.

Thanks,
Tamás