### PR TITLE
[TECHNICAL-SUPPORT] LPS-64070 The guest user can access restricted web article titles and content in Asset Publisher by using a url with the "maximized" parameter

### DIFF
--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/display/context/AssetPublisherDisplayContext.java
@@ -793,7 +793,7 @@ public class AssetPublisherDisplayContext {
 		}
 
 		_enablePermissions = GetterUtil.getBoolean(
-			_portletPreferences.getValue("enablePermissions", null));
+			_portletPreferences.getValue("enablePermissions", null), true);
 
 		return _enablePermissions;
 	}


### PR DESCRIPTION
Hi Eduardo,

by default, Asset Publisher considers permission and it cannot be changed on the UI.

However, with changing the default properties, we can make it configurable.

The problem is that this way AP won't consider permissions by default.
In my opinion it should check permissions by default, even if it's configurable.

Furthermore, with the steps described on the LPS, it's possible to obtain contents without view permission, the root cause is the same, if there is no portlet preferences available for an AP, by default there is no permission check.

Thanks,
Tamás